### PR TITLE
feat(cli): metrics cmd + post-run summary + defaults + tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "ajv": "^8.17.1",
         "axios": "^1.6.0",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
@@ -86,6 +87,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
@@ -263,16 +288,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1744,6 +1768,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -1826,7 +1874,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1842,6 +1889,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -3105,10 +3168,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -4024,6 +4086,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -24,23 +24,24 @@
   "author": "Your Name",
   "license": "MIT",
   "dependencies": {
-    "inquirer": "^9.2.12",
+    "ajv": "^8.17.1",
+    "axios": "^1.6.0",
     "chalk": "^4.1.2",
-    "ora": "^7.0.1",
-    "dotenv": "^16.3.1",
     "commander": "^11.1.0",
+    "dotenv": "^16.3.1",
     "fs-extra": "^11.1.1",
+    "inquirer": "^9.2.12",
     "joi": "^17.11.0",
-    "axios": "^1.6.0"
+    "ora": "^7.0.1"
   },
   "devDependencies": {
-    "mocha": "^10.2.0",
     "chai": "^4.3.10",
     "eslint": "^8.54.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^6.1.1"
+    "eslint-plugin-promise": "^6.1.1",
+    "mocha": "^10.2.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/src/metrics/ContextAdherenceMetric.js
+++ b/src/metrics/ContextAdherenceMetric.js
@@ -1,0 +1,71 @@
+/**
+ * Context Adherence Metric - LLM-assessed 1-10 score for using/satisfying provided context
+ */
+
+const { AssessableMetric } = require('./AssessableMetric');
+const { FileSystem } = require('../utils/FileSystem');
+
+class ContextAdherenceMetric extends AssessableMetric {
+  constructor(name, options = {}) {
+    super(name, {
+      description: 'Assesses whether the response uses/satisfies the provided prompt/repository context (1-10)',
+      unit: 'score',
+      ...options,
+    });
+    this.fs = new FileSystem(options);
+    this.minScore = 1;
+    this.maxScore = 10;
+  }
+
+  _getPromptContent(promptFile) {
+    try {
+      return require('fs').readFileSync(this.fs.getAbsolutePath(promptFile), 'utf8');
+    } catch {
+      return 'Not provided';
+    }
+  }
+
+  createAssessmentPrompt(output, context = {}) {
+    const promptContent = context.prompt ? this._getPromptContent(context.prompt) : 'Not provided';
+
+    const repoNote = context.repositoryPath
+      ? `The repository path is provided as context: ${context.repositoryPath}. Do not scan files; evaluate only based on how the response references or uses context.`
+      : 'Repository path not provided.';
+
+    const task = 'Assess whether the response appropriately uses the provided context and remains consistent with it.';
+    const criteria = `
+1. Correct usage of contextual details
+2. Consistency with constraints/assumptions in the prompt
+3. Relevance to the repository/task context
+4. Avoids claims not supported by the given context
+5. Provides references to the context when appropriate`;
+    const scale = `
+Rate 1-10:
+1-2: Poor; ignores/misuses context
+3-4: Below average; limited or inconsistent use
+5-6: Adequate; some usage but with gaps
+7-8: Good; uses context well with minor issues
+9-10: Excellent; fully consistent and contextually grounded`;
+
+    const promptSection = promptContent !== 'Not provided'
+      ? `\n\nORIGINAL PROMPT:\n\`\`\`\n${promptContent}\n\`\`\``
+      : '';
+
+    return (
+      this.createStandardPrompt(task, output, criteria, scale) +
+      `\n\n${repoNote}` +
+      promptSection
+    );
+  }
+
+  parseAssessmentResponse(response) {
+    const score = this.parseStandardResponse(response);
+    if (score < this.minScore || score > this.maxScore) {
+      throw new Error(`Context adherence score ${score} outside valid range ${this.minScore}-${this.maxScore}`);
+    }
+    return Math.round(score);
+  }
+}
+
+module.exports = { ContextAdherenceMetric };
+

--- a/src/metrics/InstructionAdherenceMetric.js
+++ b/src/metrics/InstructionAdherenceMetric.js
@@ -1,0 +1,63 @@
+/**
+ * Instruction Adherence Metric - LLM-assessed 1-10 score for following instructions in the prompt
+ */
+
+const { AssessableMetric } = require('./AssessableMetric');
+const { FileSystem } = require('../utils/FileSystem');
+
+class InstructionAdherenceMetric extends AssessableMetric {
+  constructor(name, options = {}) {
+    super(name, {
+      description: 'Assesses how well the response follows the instructions in the original prompt (1-10)',
+      unit: 'score',
+      ...options,
+    });
+    this.fs = new FileSystem(options);
+    this.minScore = 1;
+    this.maxScore = 10;
+  }
+
+  _getPromptContent(promptFile) {
+    try {
+      return require('fs').readFileSync(this.fs.getAbsolutePath(promptFile), 'utf8');
+    } catch {
+      return 'Not provided';
+    }
+  }
+
+  createAssessmentPrompt(output, context = {}) {
+    const promptContent = context.prompt ? this._getPromptContent(context.prompt) : 'Not provided';
+
+    const task = 'Assess how well the AI assistant response follows the instructions in the provided prompt.';
+    const criteria = `
+1. Direct adherence to explicit instructions
+2. Completeness of required steps
+3. Avoidance of prohibited actions or scope creep
+4. Faithfulness to requested formats/constraints
+5. Clarity and lack of unnecessary content`;
+    const scale = `
+Rate 1-10:
+1-2: Poor adherence; misses key instructions
+3-4: Below average; multiple missed or misinterpreted instructions
+5-6: Adequate; generally follows with notable gaps
+7-8: Good; follows instructions with minor issues
+9-10: Excellent; strictly follows and fully covers instructions`;
+
+    const promptSection = promptContent !== 'Not provided'
+      ? `\n\nORIGINAL PROMPT:\n\`\`\`\n${promptContent}\n\`\`\``
+      : '';
+
+    return this.createStandardPrompt(task, output, criteria, scale) + promptSection;
+  }
+
+  parseAssessmentResponse(response) {
+    const score = this.parseStandardResponse(response);
+    if (score < this.minScore || score > this.maxScore) {
+      throw new Error(`Instruction adherence score ${score} outside valid range ${this.minScore}-${this.maxScore}`);
+    }
+    return Math.round(score);
+  }
+}
+
+module.exports = { InstructionAdherenceMetric };
+

--- a/src/metrics/MeasurableMetric.js
+++ b/src/metrics/MeasurableMetric.js
@@ -7,11 +7,10 @@ const { BaseMetric } = require('./BaseMetric');
 
 class MeasurableMetric extends BaseMetric {
   constructor(name, options = {}) {
-    if (this.constructor === MeasurableMetric) {
+    super(name, options);
+    if (new.target === MeasurableMetric) {
       throw new Error('MeasurableMetric is an abstract class and cannot be instantiated directly');
     }
-    
-    super(name, options);
     this.precision = options.precision || 2;
     this.minValue = options.minValue;
     this.maxValue = options.maxValue;

--- a/src/metrics/MetricsFactory.js
+++ b/src/metrics/MetricsFactory.js
@@ -5,6 +5,10 @@
 const { Logger } = require('../utils/Logger');
 const { ResponseTimeMetric } = require('./ResponseTimeMetric');
 const { OutputQualityMetric } = require('./OutputQualityMetric');
+const { OutputFormatSuccessMetric } = require('./OutputFormatSuccessMetric');
+const { InstructionAdherenceMetric } = require('./InstructionAdherenceMetric');
+const { ContextAdherenceMetric } = require('./ContextAdherenceMetric');
+const { StepsPerTaskMetric } = require('./StepsPerTaskMetric');
 
 class MetricsFactory {
   constructor(options = {}) {
@@ -20,6 +24,10 @@ class MetricsFactory {
   registerBuiltInMetrics() {
     this.registerMetric('response_time', ResponseTimeMetric);
     this.registerMetric('output_quality', OutputQualityMetric);
+    this.registerMetric('output_format_success', OutputFormatSuccessMetric);
+    this.registerMetric('instruction_adherence', InstructionAdherenceMetric);
+    this.registerMetric('context_adherence', ContextAdherenceMetric);
+    this.registerMetric('steps_per_task', StepsPerTaskMetric);
   }
 
   /**

--- a/src/metrics/OutputFormatSuccessMetric.js
+++ b/src/metrics/OutputFormatSuccessMetric.js
@@ -1,0 +1,83 @@
+/**
+ * Output Format Success Metric - Checks if assistant output matches a configured pattern or JSON schema
+ */
+
+const { MeasurableMetric } = require('./MeasurableMetric');
+const { Logger } = require('../utils/Logger');
+const { FileSystem } = require('../utils/FileSystem');
+const Ajv = require('ajv');
+
+class OutputFormatSuccessMetric extends MeasurableMetric {
+  constructor(name, options = {}) {
+    super(name, {
+      description: 'Validates output format against a regex or JSON schema; emits 1 on success, 0 on failure',
+      unit: 'binary',
+      precision: 0,
+      ...options
+    });
+    this.logger = new Logger(options);
+    this.fs = new FileSystem(options);
+    this.metricsConfig = options.metrics_config || {};
+    this.ajv = new Ajv({ allErrors: true, strict: false });
+  }
+
+  validateValue(value) {
+    if (value === null) return true; // allow null when unconfigured or validation error
+    return value === 0 || value === 1;
+  }
+
+  async performMeasurement(output, context = {}) {
+    try {
+      if (!output) return null;
+
+      const cfg = this.metricsConfig.output_format || {};
+      const { regex, json_schema_path: schemaPath } = cfg;
+
+      if (!regex && !schemaPath) {
+        // Not configured; return null as per spec
+        return null;
+      }
+
+      // Regex path
+      if (regex) {
+        const re = new RegExp(regex);
+        return re.test(output) ? 1 : 0;
+      }
+
+      // JSON Schema path
+      if (schemaPath) {
+        try {
+          const abs = this.fs.getAbsolutePath(schemaPath);
+          if (!(await this.fs.exists(abs))) {
+            this.logger.warn(`output_format.json_schema_path does not exist: ${schemaPath}`);
+            return null;
+          }
+          const schema = await this.fs.readJSON(abs);
+
+          // Parse output as JSON
+          let data;
+          try {
+            data = JSON.parse(output);
+          } catch (e) {
+            return 0; // output is not valid JSON
+          }
+
+          const validate = this.ajv.compile(schema);
+          const valid = validate(data);
+          return valid ? 1 : 0;
+        } catch (err) {
+          this.logger.warn(`JSON schema validation error: ${err.message}`);
+          return null; // misconfiguration or schema error
+        }
+      }
+
+      return null;
+    } catch (error) {
+      this.logger.warn(`OutputFormatSuccessMetric failed: ${error.message}`);
+      return null;
+    }
+  }
+}
+
+module.exports = { OutputFormatSuccessMetric };
+

--- a/src/metrics/StepsPerTaskMetric.js
+++ b/src/metrics/StepsPerTaskMetric.js
@@ -1,0 +1,42 @@
+/**
+ * Steps Per Task Metric - Counts recognizable steps in output if available; else null
+ */
+
+const { MeasurableMetric } = require('./MeasurableMetric');
+
+class StepsPerTaskMetric extends MeasurableMetric {
+  constructor(name, options = {}) {
+    super(name, {
+      description: 'Counts steps derived from assistant output/logs when available',
+      unit: 'steps',
+      precision: 0,
+      minValue: 0,
+      ...options,
+    });
+  }
+
+  validateValue(value) {
+    if (value === null) return true; // allow null when steps not detectable
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+  }
+
+  async performMeasurement(output, context = {}) {
+    if (!output) return null;
+
+    // Heuristic: count lines that look like "Step N:" (case-insensitive)
+    const matches = output.match(/^\s*step\s+\d+\s*[:\.\-]/gim);
+    if (matches && matches.length > 0) {
+      return matches.length;
+    }
+
+    // If adapters later expose structured steps via context, use that here
+    if (Array.isArray(context.steps)) {
+      return context.steps.length;
+    }
+
+    return null;
+  }
+}
+
+module.exports = { StepsPerTaskMetric };
+

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -109,6 +109,7 @@ describe('Backbencher CLI', function() {
         expect(output).to.include('benchmark');
         expect(output).to.include('init');
         expect(output).to.include('validate');
+        expect(output).to.include('metrics');
         done();
       });
       

--- a/test/cli.summary.test.js
+++ b/test/cli.summary.test.js
@@ -1,0 +1,25 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const { BenchmarkCLI } = require('../src/cli/BenchmarkCLI');
+
+describe('BenchmarkCLI formatSummary', function () {
+  it('formats assistant summary with rates and averages', function () {
+    const cli = new BenchmarkCLI({ quiet: true });
+    const settings = { metrics_config: { agent_success: { mode: 'quality', threshold: 7 } } };
+    const results = [
+      { prompt: 'p1', assistant: 'X', runs: [
+        { run_id: 1, response_time: 1.5, output_quality: 8, output_format_success: 1 },
+        { run_id: 2, response_time: 2.5, output_quality: 6, output_format_success: 0, _evaluator_errors: ['m'] },
+        { run_id: 3, error: 'oops', response_time: null, output_quality: null }
+      ]}
+    ];
+    const txt = cli.formatSummary(results, settings);
+    expect(txt).to.include('Summary per assistant:');
+    expect(txt).to.include('- X: runs=3');
+    expect(txt).to.include('completed=66.7%');
+    expect(txt).to.include('agent_success=33.3%');
+    expect(txt).to.include('format_ok=33.3%');
+    expect(txt).to.include('llm_err=33.3%');
+  });
+});
+

--- a/test/metrics.command.test.js
+++ b/test/metrics.command.test.js
@@ -1,0 +1,43 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const path = require('path');
+const { spawn } = require('child_process');
+
+function runNode(args = []) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [path.join(__dirname, '../src/index.js'), ...args], { stdio: 'pipe' });
+    let out = '';
+    let err = '';
+    child.stdout.on('data', (d) => (out += d.toString()));
+    child.stderr.on('data', (d) => (err += d.toString()));
+    child.on('close', (code) => {
+      resolve({ code, out, err });
+    });
+    child.on('error', reject);
+  });
+}
+
+describe('metrics command', function () {
+  this.timeout(10000);
+
+  it('prints available metrics in text', async function () {
+    const { code, out } = await runNode(['metrics']);
+    expect(code).to.equal(0);
+    expect(out).to.include('Available metrics:');
+    expect(out).to.include('response_time');
+    expect(out).to.include('output_quality');
+  });
+
+  it('prints JSON with --json', async function () {
+    const { code, out } = await runNode(['metrics', '--json']);
+    expect(code).to.equal(0);
+    const parsed = JSON.parse(out);
+    expect(parsed).to.have.property('metrics');
+    expect(parsed.metrics).to.be.an('array');
+    const names = parsed.metrics.map((m) => m.name);
+    expect(names).to.include('response_time');
+    expect(parsed).to.have.property('metrics_config');
+    expect(parsed.metrics_config).to.have.property('agent_success');
+  });
+});
+

--- a/test/outputFormat.metric.test.js
+++ b/test/outputFormat.metric.test.js
@@ -1,0 +1,40 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const { OutputFormatSuccessMetric } = require('../src/metrics/OutputFormatSuccessMetric');
+const { FileSystem } = require('../src/utils/FileSystem');
+const path = require('path');
+const fs = require('fs-extra');
+
+describe('OutputFormatSuccessMetric', function () {
+  this.timeout(5000);
+
+  it('returns 1 for regex match, 0 for non-match, null when unconfigured', async function () {
+    const metric = new OutputFormatSuccessMetric('output_format_success', { metrics_config: { output_format: { regex: '^OK$' } } });
+    await metric.initialize();
+    expect(await metric.measure('OK', {})).to.equal(1);
+    expect(await metric.measure('NOPE', {})).to.equal(0);
+
+    const metric2 = new OutputFormatSuccessMetric('output_format_success', { metrics_config: { output_format: {} } });
+    await metric2.initialize();
+    expect(await metric2.measure('anything', {})).to.equal(null);
+  });
+
+  it('validates JSON against schema path', async function () {
+    const tmpDir = path.join(__dirname, 'temp-of');
+    await fs.ensureDir(tmpDir);
+    const schemaPath = path.join(tmpDir, 'schema.json');
+    await fs.writeJSON(schemaPath, { type: 'object', properties: { x: { type: 'number' } }, required: ['x'] }, { spaces: 2 });
+
+    const metric = new OutputFormatSuccessMetric('output_format_success', { metrics_config: { output_format: { json_schema_path: schemaPath } } });
+    await metric.initialize();
+
+    expect(await metric.measure('{"x": 1}', {})).to.equal(1);
+    expect(await metric.measure('{"x": "bad"}', {})).to.equal(0);
+
+    // Broken path -> null
+    const metric2 = new OutputFormatSuccessMetric('output_format_success', { metrics_config: { output_format: { json_schema_path: path.join(tmpDir, 'missing.json') } } });
+    await metric2.initialize();
+    expect(await metric2.measure('{"x": 1}', {})).to.equal(null);
+  });
+});
+

--- a/test/results.summary.test.js
+++ b/test/results.summary.test.js
@@ -1,0 +1,34 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const { ResultsStorage } = require('../src/utils/ResultsStorage');
+
+describe('ResultsStorage summary metrics', function () {
+  it('computes taskCompletionRate, agentSuccessRate (quality/completion), llmCallErrorRate, outputFormatSuccessRate', function () {
+    const storageQuality = new ResultsStorage({ metrics_config: { agent_success: { mode: 'quality', threshold: 7 } } });
+    const storageCompletion = new ResultsStorage({ metrics_config: { agent_success: { mode: 'completion' } } });
+
+    const results = [
+      {
+        prompt: 'p1',
+        assistant: 'A',
+        runs: [
+          { run_id: 1, response_time: 1.1, output_quality: 8, output_format_success: 1 },
+          { run_id: 2, response_time: 2.2, output_quality: 6, output_format_success: 0, _evaluator_errors: ['instruction_adherence'] },
+          { run_id: 3, error: 'fail', response_time: null, output_quality: null }
+        ]
+      }
+    ];
+
+    const s1 = storageQuality.generateSummary(results);
+    const a1 = s1.assistants['A'];
+    expect(a1.taskCompletionRate).to.equal(2 / 3);
+    expect(a1.agentSuccessRate).to.equal(1 / 3); // only run1 meets threshold
+    expect(a1.llmCallErrorRate).to.equal(1 / 3);
+    expect(a1.outputFormatSuccessRate).to.equal(1 / 3);
+
+    const s2 = storageCompletion.generateSummary(results);
+    const a2 = s2.assistants['A'];
+    expect(a2.agentSuccessRate).to.equal(a2.taskCompletionRate);
+  });
+});
+

--- a/test/temp-of/schema.json
+++ b/test/temp-of/schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "x": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "x"
+  ]
+}


### PR DESCRIPTION
This PR adds:

- CLI: `backbencher metrics` command with `--json` support
- CLI: Print per-assistant summary after benchmark run (completion rate, agent success rate, avg response time, avg quality, format success rate, LLM error rate)
- Settings: include default metrics in template settings.json (response_time, output_quality, output_format_success, instruction_adherence, context_adherence, steps_per_task)
- Tests: coverage for metrics command, OutputFormatSuccessMetric, ResultsStorage summary metrics, and CLI summary formatter
- Fix: MeasurableMetric abstract class constructor order to avoid runtime error in subclass instantiation
- Docs: README updates for `metrics` command and note about post-run summary

All tests pass locally via `npm test`.

Notes:
- Summary rendering is best-effort and logs a warning if it cannot compute.
- `--settings` path is now respected in SettingsManager usage during BenchmarkCLI run.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author