### PR TITLE
feat(staging): remote/local repo support with per-assistant staging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,14 @@ async function main() {
     program
       .command('benchmark')
       .description('Run benchmark tests on AI coding assistants')
-      .option('-r, --repository <path>', 'Local repository path for context (defaults to current directory)')
+      // Backward-compat alias for local path
+      .option('-r, --repository <path>', 'Local repository path for context (alias of --repo-path)')
+      // New repository sourcing options
+      .option('--repo-path <path>', 'Local repository path for benchmarking context')
+      .option('--repo-url <url>', 'Remote Git repository URL (HTTPS or SSH)')
+      .option('--branch <name>', 'Branch to use when cloning a remote repository')
+      .option('--ref <ref>', 'Git ref (commit SHA or tag) to checkout after clone')
+      .option('--stage-dir <dir>', 'Staging directory for per-assistant working copies (default: ./stage)')
       .option('-s, --settings <path>', 'Path to settings.json file')
       .option('--dry-run', 'Validate configuration without running benchmarks')
       .action(async (options) => {
@@ -76,9 +83,16 @@ async function main() {
     // Add validate command
     program
       .command('validate')
-      .description('Validate env, settings, LLM connectivity, and CLI assistant availability. If --repository is provided, validate that path; otherwise validate user home access.')
+      .description('Validate env, settings, LLM connectivity, Git installation/connectivity, and optional repository access.')
       .option('-s, --settings <path>', 'Path to settings.json file')
-      .option('-r, --repository <path>', 'Local repository path for context (must exist; warns if not a Git repo)')
+      // Backward-compat alias for local path
+      .option('-r, --repository <path>', 'Local repository path for context (alias of --repo-path)')
+      // New repository sourcing options
+      .option('--repo-path <path>', 'Local repository path for benchmarking context')
+      .option('--repo-url <url>', 'Remote Git repository URL (HTTPS or SSH)')
+      .option('--branch <name>', 'Branch to use when validating a remote repository')
+      .option('--ref <ref>', 'Git ref (commit SHA or tag) to validate')
+      .option('--stage-dir <dir>', 'Staging directory (default: ./stage)')
       .action(async (options) => {
         const cli = new BenchmarkCLI({
           verbose: program.opts().verbose,

--- a/src/utils/GitManager.js
+++ b/src/utils/GitManager.js
@@ -1,0 +1,89 @@
+/**
+ * GitManager - helper for Git operations and connectivity checks
+ */
+
+const { spawn } = require('child_process');
+const path = require('path');
+const { Logger } = require('./Logger');
+
+class GitManager {
+  constructor(options = {}) {
+    this.options = options;
+    this.logger = new Logger(options);
+  }
+
+  runGit(args, opts = {}) {
+    return new Promise((resolve, reject) => {
+      const proc = spawn('git', args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        ...opts,
+      });
+      let stdout = '';
+      let stderr = '';
+      proc.stdout.on('data', (d) => (stdout += d.toString()));
+      proc.stderr.on('data', (d) => (stderr += d.toString()));
+      proc.on('close', (code) => {
+        if (code === 0) resolve({ code, stdout: stdout.trim(), stderr: stderr.trim() });
+        else reject(new Error(stderr || `git ${args.join(' ')} exited with ${code}`));
+      });
+      proc.on('error', (err) => reject(err));
+    });
+  }
+
+  async getVersion() {
+    const { stdout } = await this.runGit(['--version']);
+    // Example: git version 2.42.0
+    return stdout.trim();
+  }
+
+  async ensureMinVersion(min = '2.30.0') {
+    const v = await this.getVersion();
+    const match = v.match(/git\s+version\s+(\d+)\.(\d+)\.(\d+)/i);
+    if (!match) throw new Error(`Unable to parse git version: ${v}`);
+    const cur = match.slice(1, 4).map((n) => parseInt(n, 10));
+    const minParts = min.split('.').map((n) => parseInt(n, 10));
+    const ok = (cur[0] > minParts[0]) || (cur[0] === minParts[0] && cur[1] > minParts[1]) || (cur[0] === minParts[0] && cur[1] === minParts[1] && cur[2] >= minParts[2]);
+    if (!ok) throw new Error(`Git version ${v} is below required minimum ${min}`);
+    return v;
+  }
+
+  /**
+   * Test remote connectivity with ls-remote
+   * For HTTPS, you can pass a token to add Authorization header without leaking via URL.
+   */
+  async testConnectivity(url, token) {
+    const args = token ? ['-c', `http.extraHeader=Authorization: Bearer ${token}`, 'ls-remote', '--heads', '--tags', url] : ['ls-remote', '--heads', '--tags', url];
+    try {
+      await this.runGit(args);
+      return true;
+    } catch (e) {
+      this.logger.debug(`Git connectivity failed for ${url}: ${e.message}`);
+      return false;
+    }
+  }
+
+  /**
+   * Clone a remote repository
+   */
+  async clone(url, dest, { branch, token } = {}) {
+    const args = [];
+    if (token) args.push('-c', `http.extraHeader=Authorization: Bearer ${token}`);
+    args.push('clone');
+    if (branch) args.push('--branch', branch);
+    args.push('--depth', '1');
+    args.push(url, dest);
+    await this.runGit(args);
+  }
+
+  /**
+   * Checkout a specific ref (commit or tag) in a repository
+   */
+  async checkoutRef(dest, ref) {
+    if (!ref) return;
+    await this.runGit(['-C', dest, 'fetch', '--depth', '1', 'origin', ref]).catch(() => {});
+    await this.runGit(['-C', dest, 'checkout', '--detach', ref]);
+  }
+}
+
+module.exports = { GitManager };
+

--- a/src/utils/StagingManager.js
+++ b/src/utils/StagingManager.js
@@ -1,0 +1,66 @@
+/**
+ * StagingManager - manages per-assistant working directories
+ */
+
+const path = require('path');
+const fs = require('fs-extra');
+const { FileSystem } = require('./FileSystem');
+const { Logger } = require('./Logger');
+const { GitManager } = require('./GitManager');
+
+class StagingManager {
+  constructor(options = {}) {
+    this.options = options;
+    this.fs = new FileSystem(options);
+    this.logger = new Logger(options);
+    this.git = new GitManager(options);
+  }
+
+  agentSlug(name) {
+    return String(name).toLowerCase().replace(/[^a-z0-9\-_]+/g, '-');
+  }
+
+  getAgentDir(stageDir, assistantName) {
+    const slug = this.agentSlug(assistantName);
+    return path.join(this.fs.getAbsolutePath(stageDir || './stage'), slug);
+  }
+
+  async ensureOutputDir(agentDir, runId) {
+    const outDir = path.join(agentDir, 'backbencher_output', String(runId || '')); // caller may pass undefined
+    await fs.ensureDir(path.dirname(outDir));
+    return path.join(agentDir, 'backbencher_output');
+  }
+
+  async prepareForAssistant(assistantName, { repo_url, repo_path, stage_dir = './stage', branch, ref, tokenEnv } = {}) {
+    const agentDir = this.getAgentDir(stage_dir, assistantName);
+
+    if (await this.fs.exists(agentDir)) {
+      const msg = `Staging directory already exists for agent '${assistantName}' at ${agentDir}. Delete it or change --stage-dir. Exiting per clean-state policy.`;
+      this.logger.warn(msg);
+      throw new Error(msg);
+    }
+
+    await this.fs.ensureDir(path.dirname(agentDir));
+
+    if (repo_url) {
+      const token = process.env[tokenEnv || 'GH_TOKEN'] || process.env.GIT_TOKEN;
+      this.logger.info(`Cloning ${repo_url} into ${agentDir}${branch ? ` (branch: ${branch})` : ''}${ref ? ` (ref: ${ref})` : ''}`);
+      await this.git.clone(repo_url, agentDir, { branch, token });
+      if (ref) await this.git.checkoutRef(agentDir, ref);
+    } else if (repo_path) {
+      const absSrc = this.fs.getAbsolutePath(repo_path);
+      this.logger.info(`Copying from ${absSrc} into ${agentDir}`);
+      await fs.copy(absSrc, agentDir, { dereference: true, filter: (src) => !/\.git(\/|$)/.test(src) });
+    } else {
+      throw new Error('prepareForAssistant requires repo_url or repo_path');
+    }
+
+    // Output artifacts directory (parent)
+    await fs.ensureDir(path.join(agentDir, 'backbencher_output'));
+
+    return agentDir;
+  }
+}
+
+module.exports = { StagingManager };
+

--- a/src/utils/Validator.js
+++ b/src/utils/Validator.js
@@ -335,6 +335,23 @@ class Validator {
               string: { minLength: 1 }
             });
           }
+          if (args.repoPath) {
+            this.errorHandler.validateInput(args.repoPath, {
+              required: true,
+              type: 'string',
+              string: { minLength: 1 }
+            });
+          }
+          if (args.repoUrl) {
+            this.errorHandler.validateInput(args.repoUrl, {
+              required: true,
+              type: 'string',
+              string: { minLength: 1 }
+            });
+          }
+          if (args.repoUrl && (args.repoPath || args.repository)) {
+            throw new Error('Exactly one of --repo-url or --repo-path/--repository is allowed');
+          }
           if (args.settings) {
             this.errorHandler.validateInput(args.settings, {
               required: true,
@@ -351,6 +368,23 @@ class Validator {
               type: 'string',
               string: { minLength: 1 }
             });
+          }
+          if (args.repoPath) {
+            this.errorHandler.validateInput(args.repoPath, {
+              required: true,
+              type: 'string',
+              string: { minLength: 1 }
+            });
+          }
+          if (args.repoUrl) {
+            this.errorHandler.validateInput(args.repoUrl, {
+              required: true,
+              type: 'string',
+              string: { minLength: 1 }
+            });
+          }
+          if (args.repoUrl && (args.repoPath || args.repository)) {
+            throw new Error('Exactly one of --repo-url or --repo-path/--repository is allowed');
           }
           break;
           


### PR DESCRIPTION
This PR adds first-class support for benchmarking against local or remote Git repositories with per-assistant staging.

Highlights:
- New CLI flags: --repo-url, --repo-path (alias: -r/--repository), --stage-dir, --branch, --ref
- Git checks in `validate`: min version >= 2.30.0 and connectivity to a public repo (chromium) and optionally the provided --repo-url
- New utilities:
  - GitManager: version detection, ls-remote, clone with optional HTTPS token header, checkout ref
  - StagingManager: per-assistant working copies under <stage-dir>/<agent_slug>, clean-state policy, output dir prep
- Runner: uses per-assistant staged working directory so each assistant runs in isolation
- Validator: CLI arg validation for mutual exclusivity of --repo-url vs --repo-path/--repository
- Settings: template/schema now include repo_url, repo_path, stage_dir, branch, ref; XOR enforcement in schema
- Docs: README updated with remote repo usage, auth, troubleshooting

Testing:
- All existing tests passing: `npm test`

Follow-ups:
- Add targeted unit tests for GitManager/StagingManager using mocks

Thanks!

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author